### PR TITLE
Fix error handeling

### DIFF
--- a/go-build
+++ b/go-build
@@ -3,9 +3,6 @@
 # Script to test building go applications
 #
 
-# Make sure we capture failures from pipe commands
-set -o pipefail
-
 NUBIS_VOLUME='/nubis/files'
 export GOPATH='/nubis/go'
 BUILD_PATH="${GOPATH}/src/build"

--- a/main.sh
+++ b/main.sh
@@ -4,8 +4,7 @@
 # This is an options script used to invoke various other tools or scripts
 #
 
-# Make sure we capture failures from pipe commands
-set -o pipefail
+ERRORS=0
 
 show-help () {
     echo -en "Usage: $0 [options] command\n\n"
@@ -30,12 +29,15 @@ while [ "$1" != "" ]; do
         ;;
         go-build )
             go-build
+            ERRORS=$(( ERRORS + $? ))
         ;;
         run-checks | lint )
             run-checks
+            ERRORS=$(( ERRORS + $? ))
         ;;
         run-builds )
             run-builds
+            ERRORS=$(( ERRORS + $? ))
         ;;
         * )
             show-help
@@ -43,3 +45,5 @@ while [ "$1" != "" ]; do
     esac
     shift
 done
+
+exit "${ERRORS}"

--- a/run-checks
+++ b/run-checks
@@ -3,9 +3,6 @@
 # shellcheck disable=SC2185
 set -e
 
-# Make sure we capture failures from pipe commands
-set -o pipefail
-
 ERRORS=0
 
 # Puppet Checks


### PR DESCRIPTION
To aggressive with pipefail which breaks a number of tests. This could
(should) be fixed in a better way, but reverting to old behavior for
now.

Also. Added error trapping to main.sh to raise errors from wrapped
commands.